### PR TITLE
adding markdown rendering to post content

### DIFF
--- a/Modules/Timeline/PostView.swift
+++ b/Modules/Timeline/PostView.swift
@@ -22,7 +22,7 @@ struct PostView: View {
 					}.fontWeight(.bold)
 					Text(post.author.handle)
 				}
-				Text(post.content ?? "")
+				Text(.init(post.content ?? ""))
 					.padding(EdgeInsets(top: 4.0, leading: 2.0, bottom: 4.0, trailing: 1.0))
 				PostAttachmentView(attachments: post.attachments)
 				PostStatusView(


### PR DESCRIPTION
Text(.init(stringvariable)) creates a localized string key from the variable and renders it as markdown.

Text"markdown string here") works only with string literals as they can be interpreted as localized string keys. -> initialize one:
![Screenshot 2025-03-31 at 10 23 33](https://github.com/user-attachments/assets/2a0cfe03-cabe-451e-9a9c-00d198977746)
e.g. links are now clickable (but #'s are of course not (yet))